### PR TITLE
ViewScores Presenter and HomePageView changed to adhere to Observer Design Pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,12 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/interface_adapter/view_scores/ViewScoresPresenter.java
+++ b/src/interface_adapter/view_scores/ViewScoresPresenter.java
@@ -31,8 +31,9 @@ public class ViewScoresPresenter implements ViewScoresOutputBoundary {
             viewScoresState.setViewScoresMessage(
                     "Your last 10 scores: " + scoresArray.stream().map(String::valueOf).collect(Collectors.joining("%, "))
                     + "%\nAverage from your last 10 scores: " + String.format("%.2f", sumOfScores/scoresArray.size()) + "%"
-                    + "\nYour last score: " + String.format("%.2f", scoresArray.get(scoresArray.size() - 1))
+                    + "\nYour last score: " + String.format("%.2f", scoresArray.get(scoresArray.size() - 1)) + "%"
             );
         }
+        viewScoresViewModel.firePropertyChanged();
     }
 }

--- a/src/view/HomePageView.java
+++ b/src/view/HomePageView.java
@@ -55,7 +55,7 @@ public class HomePageView extends BackgroundImagePanel implements ActionListener
                 evt -> {
                     if (evt.getSource().equals(viewScores)) {
                         HomePageView.this.viewScoresController.execute();
-                        JOptionPane.showMessageDialog(this,viewScoresViewModel.getState().getViewScoresMessage());
+                        // JOptionPane.showMessageDialog(this,viewScoresViewModel.getState().getViewScoresMessage());
                     }
                 }
         );
@@ -99,5 +99,6 @@ public class HomePageView extends BackgroundImagePanel implements ActionListener
     }
 
     private void viewScoresPropertyChange(PropertyChangeEvent evt) {
+        JOptionPane.showMessageDialog(this, viewScoresViewModel.getState().getViewScoresMessage());
     }
 }


### PR DESCRIPTION
I've modified the ViewScores Presenter and HomePageView to better adhere to the Observer Design Pattern. In particular, I've made sure that:

- A JDialog box is not opened _after_ viewScoresController.execute() is called, but rather, opened as a result of a property change
- A property change is fired only after the ViewScoresPresenter has finished all of its operations; that is, only after the ViewScoresMessage in ViewScoresState has been updated.

This should help maintain consistency between the JDialog box and the implementation of the ViewScoresButton/ViewScoresMessage.