### PR TITLE
Return home use case

### DIFF
--- a/src/app/CreateQuizUseCaseFactory.java
+++ b/src/app/CreateQuizUseCaseFactory.java
@@ -3,7 +3,7 @@ package app;
 import data_access.file_accessors.graphics.CreateQuizGraphicsAccessInterface;
 import data_access.file_accessors.graphics.LoadingScreenGraphicsAccessInterface;
 import entity.Pair;
-import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewModelManager;
 import interface_adapter.create_quiz.CreateQuizController;
 import interface_adapter.create_quiz.CreateQuizPresenter;
 import interface_adapter.create_quiz.CreateQuizViewModel;
@@ -20,7 +20,7 @@ public class CreateQuizUseCaseFactory {
     public static Pair<CreateQuizView, LoadingScreenView> create(
             CreateQuizDataAccessInterface createQuizDataAccessInterface,
             CreateQuizFactoryRetrieverInterface createQuizFactoryRetrieverInterface,
-            ViewManagerModel viewManagerModel,
+            ViewModelManager viewModelManager,
             CreateQuizViewModel createQuizViewModel,
             LoadingScreenViewModel loadingScreenViewModel,
             SubmitQuizViewModel submitQuizViewModel,
@@ -28,7 +28,7 @@ public class CreateQuizUseCaseFactory {
             LoadingScreenGraphicsAccessInterface loadingScreenGraphicsAccessInterface) {
 
         CreateQuizController createQuizController = createCreateQuizController(createQuizDataAccessInterface,
-                createQuizFactoryRetrieverInterface, viewManagerModel, createQuizViewModel, loadingScreenViewModel,
+                createQuizFactoryRetrieverInterface, viewModelManager, createQuizViewModel, loadingScreenViewModel,
                 submitQuizViewModel);
 
         return new Pair<>(new CreateQuizView(createQuizController, createQuizViewModel,
@@ -40,12 +40,12 @@ public class CreateQuizUseCaseFactory {
 
     private static CreateQuizController createCreateQuizController(CreateQuizDataAccessInterface createQuizDataAccessInterface,
                                                                    CreateQuizFactoryRetrieverInterface createQuizFactoryRetrieverInterface,
-                                                                   ViewManagerModel viewManagerModel,
+                                                                   ViewModelManager viewModelManager,
                                                                    CreateQuizViewModel createQuizViewModel,
                                                                    LoadingScreenViewModel loadingScreenViewModel,
                                                                    SubmitQuizViewModel submitQuizViewModel)
     {
-        CreateQuizOutputBoundary createQuizOutputBoundary = new CreateQuizPresenter(viewManagerModel,
+        CreateQuizOutputBoundary createQuizOutputBoundary = new CreateQuizPresenter(viewModelManager,
                 createQuizViewModel, loadingScreenViewModel, submitQuizViewModel);
         CreateQuizInputBoundary createQuizInputBoundary = new CreateQuizInteractor(createQuizDataAccessInterface,
                 createQuizFactoryRetrieverInterface, createQuizOutputBoundary);

--- a/src/app/HomePageUseCaseFactory.java
+++ b/src/app/HomePageUseCaseFactory.java
@@ -1,7 +1,7 @@
 package app;
 
 import data_access.file_accessors.graphics.HomePageGraphicsAccessInterface;
-import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewModelManager;
 import interface_adapter.create_quiz.CreateQuizViewModel;
 import interface_adapter.start_new_game.StartNewGameController;
 import interface_adapter.start_new_game.StartNewGamePresenter;
@@ -25,31 +25,31 @@ public class HomePageUseCaseFactory
     private HomePageUseCaseFactory() {}
 
     public static HomePageView create(
-            ViewManagerModel viewManagerModel, StartNewGameViewModel startNewGameViewModel, ViewScoresViewModel viewScoresViewModel,
+            ViewModelManager viewModelManager, StartNewGameViewModel startNewGameViewModel, ViewScoresViewModel viewScoresViewModel,
             CreateQuizViewModel createQuizViewModel, HomePageGraphicsAccessInterface graphicsAccessInterface,
             StartNewGameDataAccessInterface startNewGameDataAccessObject, ViewScoresDataAccessInterface viewScoresDataAccessObject) {
 
-        StartNewGameController startNewGameController = createStartNewGameUseCase(viewManagerModel, createQuizViewModel,
+        StartNewGameController startNewGameController = createStartNewGameUseCase(viewModelManager, createQuizViewModel,
                 startNewGameDataAccessObject);
-        ViewScoresController viewScoresController = createViewScoresUseCase(viewManagerModel, viewScoresViewModel,
+        ViewScoresController viewScoresController = createViewScoresUseCase(viewModelManager, viewScoresViewModel,
                 viewScoresDataAccessObject);
         return new HomePageView(startNewGameViewModel, viewScoresViewModel, startNewGameController, viewScoresController,
                 graphicsAccessInterface.getHomePageBackgroundImage());
     }
 
-    private static StartNewGameController createStartNewGameUseCase(ViewManagerModel viewManagerModel,
+    private static StartNewGameController createStartNewGameUseCase(ViewModelManager viewModelManager,
                                                                     CreateQuizViewModel createQuizViewModel,
                                                                     StartNewGameDataAccessInterface startNewGameDataAccessObject)
     {
-        StartNewGameOutputBoundary startNewGameOutputBoundary = new StartNewGamePresenter(viewManagerModel, createQuizViewModel);
+        StartNewGameOutputBoundary startNewGameOutputBoundary = new StartNewGamePresenter(viewModelManager, createQuizViewModel);
         StartNewGameInputBoundary startNewGameInputBoundary = new StartNewGameInteractor(startNewGameDataAccessObject, startNewGameOutputBoundary);
         return new StartNewGameController(startNewGameInputBoundary);
     }
 
-    private static ViewScoresController createViewScoresUseCase(ViewManagerModel viewManagerModel,
+    private static ViewScoresController createViewScoresUseCase(ViewModelManager viewModelManager,
                                                                 ViewScoresViewModel viewScoresViewModel,
                                                                 ViewScoresDataAccessInterface viewScoresDataAccessObject) {
-        ViewScoresOutputBoundary viewScoresOutputBoundary = new ViewScoresPresenter(viewManagerModel, viewScoresViewModel);
+        ViewScoresOutputBoundary viewScoresOutputBoundary = new ViewScoresPresenter(viewModelManager, viewScoresViewModel);
         ViewScoresInputBoundary viewScoresInputBoundary = new ViewScoresInteractor(viewScoresDataAccessObject, viewScoresOutputBoundary);
         return new ViewScoresController(viewScoresInputBoundary);
     }

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -99,12 +99,13 @@ public class Main
         views.add(createQuizViewUseCaseViews.first(), CreateQuizView.VIEW_NAME);
         views.add(createQuizViewUseCaseViews.second(), LoadingScreenView.VIEW_NAME);
 
-        GameView gameView = SubmitQuizUseCaseFactory.create(viewModelManager, submitQuizViewModel, userScoresDataAccessObject);
+        GameView gameView = SubmitQuizUseCaseFactory.create(viewModelManager, submitQuizViewModel, returnHomeViewModel,
+                userScoresDataAccessObject);
         views.add(gameView, GameView.VIEW_NAME);
 
         ResultsView resultsView = ReturnHomeUseCaseFactory.create(viewModelManager, returnHomeViewModel,
                 startNewGameViewModel);
-        views.add(resultsView);
+        views.add(resultsView, ResultsView.VIEW_NAME);
 
         viewModelManager.setActiveView(HomePageView.VIEW_NAME);
         viewModelManager.firePropertyChanged();

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -9,16 +9,14 @@ import data_access.file_accessors.UserPreferenceDataAccessObject;
 import data_access.file_accessors.UserScoresDataAccessObject;
 import data_access.file_accessors.graphics.ImageType;
 import entity.Pair;
-import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewModelManager;
 import interface_adapter.create_quiz.CreateQuizViewModel;
 import interface_adapter.loading_screen.LoadingScreenViewModel;
+import interface_adapter.return_home.ReturnHomeViewModel;
 import interface_adapter.start_new_game.StartNewGameViewModel;
 import interface_adapter.submit_quiz.SubmitQuizViewModel;
 import interface_adapter.view_scores.ViewScoresViewModel;
-import view.CreateQuizView;
-import view.HomePageView;
-import view.LoadingScreenView;
-import view.ViewManager;
+import view.*;
 
 import javax.swing.*;
 import java.awt.*;
@@ -37,14 +35,15 @@ public class Main
         JPanel views = new JPanel(cardLayout);
         application.add(views);
 
-        ViewManagerModel viewManagerModel = new ViewManagerModel();
-        new ViewManager(views, cardLayout, viewManagerModel);
+        ViewModelManager viewModelManager = new ViewModelManager();
+        new ViewManager(views, cardLayout, viewModelManager);
 
         StartNewGameViewModel startNewGameViewModel = new StartNewGameViewModel();
         ViewScoresViewModel viewScoresViewModel = new ViewScoresViewModel();
         CreateQuizViewModel createQuizViewModel = new CreateQuizViewModel();
         LoadingScreenViewModel loadingScreenViewModel = new LoadingScreenViewModel();
         SubmitQuizViewModel submitQuizViewModel = new SubmitQuizViewModel();
+        ReturnHomeViewModel returnHomeViewModel = new ReturnHomeViewModel();
 
         GraphicsAccessObject graphicsAccessObject;
         UserScoresDataAccessObject userScoresDataAccessObject;
@@ -88,20 +87,24 @@ public class Main
 
         application.setIconImage(graphicsAccessObject.getLogoImage());
 
-        HomePageView homePageView = HomePageUseCaseFactory.create(viewManagerModel, startNewGameViewModel,
+        HomePageView homePageView = HomePageUseCaseFactory.create(viewModelManager, startNewGameViewModel,
                 viewScoresViewModel, createQuizViewModel, graphicsAccessObject, userPreferenceDataAccessObject,
                 userScoresDataAccessObject);
         views.add(homePageView, HomePageView.VIEW_NAME);
 
         Pair<CreateQuizView, LoadingScreenView> createQuizViewUseCaseViews =
-                CreateQuizUseCaseFactory.create(userPreferenceDataAccessObject, factoryRetriever, viewManagerModel,
+                CreateQuizUseCaseFactory.create(userPreferenceDataAccessObject, factoryRetriever, viewModelManager,
                         createQuizViewModel, loadingScreenViewModel, submitQuizViewModel, graphicsAccessObject,
                         graphicsAccessObject);
         views.add(createQuizViewUseCaseViews.first(), CreateQuizView.VIEW_NAME);
         views.add(createQuizViewUseCaseViews.second(), LoadingScreenView.VIEW_NAME);
 
-        viewManagerModel.setActiveView(HomePageView.VIEW_NAME);
-        viewManagerModel.firePropertyChanged();
+        ResultsView resultsView = ReturnHomeUseCaseFactory.create(viewModelManager, returnHomeViewModel,
+                startNewGameViewModel);
+        views.add(resultsView);
+
+        viewModelManager.setActiveView(HomePageView.VIEW_NAME);
+        viewModelManager.firePropertyChanged();
 
         application.pack();
         application.setVisible(true);

--- a/src/app/ReturnHomeUseCaseFactory.java
+++ b/src/app/ReturnHomeUseCaseFactory.java
@@ -1,0 +1,32 @@
+package app;
+
+import interface_adapter.ViewModelManager;
+import interface_adapter.return_home.ReturnHomeController;
+import interface_adapter.return_home.ReturnHomePresenter;
+import interface_adapter.return_home.ReturnHomeViewModel;
+import interface_adapter.start_new_game.StartNewGameViewModel;
+import use_case.return_home.ReturnHomeInputBoundary;
+import use_case.return_home.ReturnHomeInteractor;
+import use_case.return_home.ReturnHomeOutputBoundary;
+import view.ResultsView;
+
+public class ReturnHomeUseCaseFactory {
+    /** Prevent instantiation. */
+    private ReturnHomeUseCaseFactory() {}
+
+    public static ResultsView create(
+            ViewModelManager viewModelManager, ReturnHomeViewModel returnHomeViewModel,
+            StartNewGameViewModel startNewGameViewModel) {
+
+        ReturnHomeController returnHomeController = createReturnHomeUseCase(viewModelManager, startNewGameViewModel);
+        return new ResultsView(returnHomeViewModel, returnHomeController);
+    }
+
+    private static ReturnHomeController createReturnHomeUseCase(ViewModelManager viewModelManager,
+                                                                StartNewGameViewModel startNewGameViewModel)
+    {
+        ReturnHomeOutputBoundary returnHomeOutputBoundary = new ReturnHomePresenter(viewModelManager, startNewGameViewModel);
+        ReturnHomeInputBoundary returnHomeInputBoundary = new ReturnHomeInteractor(returnHomeOutputBoundary);
+        return new ReturnHomeController(returnHomeInputBoundary);
+    }
+}

--- a/src/app/SubmitQuizUseCaseFactory.java
+++ b/src/app/SubmitQuizUseCaseFactory.java
@@ -2,6 +2,7 @@ package app;
 
 
 import interface_adapter.ViewModelManager;
+import interface_adapter.return_home.ReturnHomeViewModel;
 import interface_adapter.submit_quiz.SubmitQuizController;
 import interface_adapter.submit_quiz.SubmitQuizPresenter;
 import interface_adapter.submit_quiz.SubmitQuizViewModel;
@@ -17,17 +18,19 @@ public class SubmitQuizUseCaseFactory {
 
     public static GameView create(ViewModelManager viewModelManager,
                                   SubmitQuizViewModel submitQuizViewModel,
+                                  ReturnHomeViewModel returnHomeViewModel,
                                   SubmitQuizDataAccessInterface submitQuizDataAccessObject) {
         SubmitQuizController submitQuizController = createSubmitQuizUseCase(viewModelManager, submitQuizViewModel,
-                submitQuizDataAccessObject);
+                returnHomeViewModel, submitQuizDataAccessObject);
 
         return new GameView(submitQuizViewModel, submitQuizController);
     }
 
     public static SubmitQuizController createSubmitQuizUseCase(ViewModelManager viewModelManager,
                                                                SubmitQuizViewModel submitQuizViewModel,
+                                                               ReturnHomeViewModel returnHomeViewModel,
                                                                SubmitQuizDataAccessInterface submitQuizDataAccessObject) {
-        SubmitQuizOutputBoundary submitQuizOutputBoundary = new SubmitQuizPresenter(viewModelManager, submitQuizViewModel);
+        SubmitQuizOutputBoundary submitQuizOutputBoundary = new SubmitQuizPresenter(viewModelManager, submitQuizViewModel, returnHomeViewModel);
         SubmitQuizInputBoundary submitQuizInputBoundary = new SubmitQuizInteractor(submitQuizDataAccessObject, submitQuizOutputBoundary);
         return new SubmitQuizController(submitQuizInputBoundary);
     }

--- a/src/entity/quiz/MCQuiz.java
+++ b/src/entity/quiz/MCQuiz.java
@@ -29,7 +29,7 @@ public class MCQuiz implements MCQuizInterface
     {
         if ((questions != null) && (submitted))
         {
-            return new SubmittedQuizDisplay((float) score/questions.length,
+            return new SubmittedQuizDisplay((float) score/questions.length * 100f,
                     getQuestionsArray(MCQuestion::getQuery, String[]::new),
                     getQuestionsArray(MCQuestion::getChoices, String[][]::new),
                     getQuestionsArray(MCQuestion::getAnswer, Integer[]::new),

--- a/src/interface_adapter/ViewModelManager.java
+++ b/src/interface_adapter/ViewModelManager.java
@@ -3,7 +3,7 @@ package interface_adapter;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
-public class ViewManagerModel {
+public class ViewModelManager {
     private String activeViewName;
 
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);

--- a/src/interface_adapter/create_quiz/CreateQuizPresenter.java
+++ b/src/interface_adapter/create_quiz/CreateQuizPresenter.java
@@ -1,6 +1,6 @@
 package interface_adapter.create_quiz;
 
-import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewModelManager;
 import interface_adapter.loading_screen.LoadingScreenViewModel;
 import interface_adapter.submit_quiz.SubmitQuizState;
 import interface_adapter.submit_quiz.SubmitQuizViewModel;
@@ -12,11 +12,11 @@ public class CreateQuizPresenter implements CreateQuizOutputBoundary {
     private final LoadingScreenViewModel loadingScreenViewModel;
     private final SubmitQuizViewModel submitQuizViewModel;
 
-    private final ViewManagerModel viewManagerModel;
+    private final ViewModelManager viewModelManager;
 
-    public CreateQuizPresenter(ViewManagerModel viewManagerModel, CreateQuizViewModel createQuizViewModel,
+    public CreateQuizPresenter(ViewModelManager viewModelManager, CreateQuizViewModel createQuizViewModel,
                                LoadingScreenViewModel loadingScreenViewModel, SubmitQuizViewModel submitQuizViewModel) {
-        this.viewManagerModel = viewManagerModel;
+        this.viewModelManager = viewModelManager;
         this.createQuizViewModel = createQuizViewModel;
         this.loadingScreenViewModel = loadingScreenViewModel;
         this.submitQuizViewModel = submitQuizViewModel;
@@ -24,8 +24,8 @@ public class CreateQuizPresenter implements CreateQuizOutputBoundary {
 
     @Override
     public void prepareLoadView() {
-        viewManagerModel.setActiveView(loadingScreenViewModel.getViewName());
-        viewManagerModel.firePropertyChanged();
+        viewModelManager.setActiveView(loadingScreenViewModel.getViewName());
+        viewModelManager.firePropertyChanged();
     }
 
     @Override
@@ -35,8 +35,8 @@ public class CreateQuizPresenter implements CreateQuizOutputBoundary {
         submitQuizState.setReading(outputData.reading());
         submitQuizViewModel.firePropertyChanged();
 
-        viewManagerModel.setActiveView(submitQuizViewModel.getViewName());
-        viewManagerModel.firePropertyChanged();
+        viewModelManager.setActiveView(submitQuizViewModel.getViewName());
+        viewModelManager.firePropertyChanged();
     }
 
     @Override
@@ -45,7 +45,7 @@ public class CreateQuizPresenter implements CreateQuizOutputBoundary {
         createQuizStateState.setErrorMessage(error);
         createQuizViewModel.firePropertyChanged();
 
-        viewManagerModel.setActiveView(createQuizViewModel.getViewName());
-        viewManagerModel.firePropertyChanged();
+        viewModelManager.setActiveView(createQuizViewModel.getViewName());
+        viewModelManager.firePropertyChanged();
     }
 }

--- a/src/interface_adapter/create_quiz/CreateQuizViewModel.java
+++ b/src/interface_adapter/create_quiz/CreateQuizViewModel.java
@@ -15,7 +15,7 @@ public class CreateQuizViewModel extends ViewModel {
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
 
     public CreateQuizViewModel() {
-        super("create quiz");
+        super("Create Quiz");
     }
 
     public CreateQuizState getState() {

--- a/src/interface_adapter/loading_screen/LoadingScreenViewModel.java
+++ b/src/interface_adapter/loading_screen/LoadingScreenViewModel.java
@@ -11,7 +11,7 @@ public class LoadingScreenViewModel extends ViewModel {
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
 
     public LoadingScreenViewModel() {
-        super("loading screen");
+        super("Loading Screen");
     }
 
     @Override

--- a/src/interface_adapter/return_home/ReturnHomePresenter.java
+++ b/src/interface_adapter/return_home/ReturnHomePresenter.java
@@ -1,23 +1,21 @@
 package interface_adapter.return_home;
 
-import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewModelManager;
+import interface_adapter.start_new_game.StartNewGameViewModel;
 import use_case.return_home.ReturnHomeOutputBoundary;
-import use_case.return_home.ReturnHomeOutputData;
 
 public class ReturnHomePresenter implements ReturnHomeOutputBoundary {
-    private final ReturnHomeViewModel returnHomeViewModel;
-    private final ViewManagerModel viewManagerModel;
+    private final StartNewGameViewModel startNewGameViewModel;
+    private final ViewModelManager viewModelManager;
 
-    public ReturnHomePresenter(ViewManagerModel viewManagerModel, ReturnHomeViewModel returnHomeViewModel) {
-        this.viewManagerModel = viewManagerModel;
-        this.returnHomeViewModel = returnHomeViewModel;
+    public ReturnHomePresenter(ViewModelManager viewModelManager, StartNewGameViewModel startNewGameViewModel) {
+        this.viewModelManager = viewModelManager;
+        this.startNewGameViewModel = startNewGameViewModel;
     }
 
     @Override
-    public void prepareSuccessView(ReturnHomeOutputData outputData) {
-        ReturnHomeState returnHomeState = returnHomeViewModel.getState();
-        // Change state
-        this.returnHomeViewModel.setState(returnHomeState);
-        returnHomeViewModel.firePropertyChanged();
+    public void prepareSuccessView() {
+        viewModelManager.setActiveView(startNewGameViewModel.getViewName());
+        viewModelManager.firePropertyChanged();
     }
 }

--- a/src/interface_adapter/return_home/ReturnHomeState.java
+++ b/src/interface_adapter/return_home/ReturnHomeState.java
@@ -1,0 +1,17 @@
+package interface_adapter.return_home;
+
+import entity.quiz.SubmittedQuizDisplay;
+
+public class ReturnHomeState {
+    private SubmittedQuizDisplay quizDisplay;
+
+    public ReturnHomeState() {}
+
+    public SubmittedQuizDisplay getQuizDisplay() {
+        return this.quizDisplay;
+    }
+
+    public void setQuizDisplay(SubmittedQuizDisplay quizDisplay) {
+        this.quizDisplay = quizDisplay;
+    }
+}

--- a/src/interface_adapter/return_home/ReturnHomeState.java
+++ b/src/interface_adapter/return_home/ReturnHomeState.java
@@ -1,5 +1,0 @@
-package interface_adapter.return_home;
-
-public class ReturnHomeState {
-
-}

--- a/src/interface_adapter/return_home/ReturnHomeViewModel.java
+++ b/src/interface_adapter/return_home/ReturnHomeViewModel.java
@@ -6,15 +6,28 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
 public class ReturnHomeViewModel extends ViewModel {
+    public static final String RETURN_HOME_BUTTON_LABEL = "Return Home";
+    public static final String HEADER_LABEL = "Results";
+
+    private ReturnHomeState state = new ReturnHomeState();
+
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
 
     public ReturnHomeViewModel() {
-        super("return home");
+        super("Results");
+    }
+
+    public ReturnHomeState getState() {
+        return this.state;
+    }
+
+    public void setState(ReturnHomeState quizState) {
+        this.state = quizState;
     }
 
     @Override
     public void firePropertyChanged() {
-        support.firePropertyChange("state", null, null);
+        support.firePropertyChange("state", null, this.state);
     }
 
     @Override

--- a/src/interface_adapter/return_home/ReturnHomeViewModel.java
+++ b/src/interface_adapter/return_home/ReturnHomeViewModel.java
@@ -6,24 +6,15 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
 public class ReturnHomeViewModel extends ViewModel {
-    private ReturnHomeState state = new ReturnHomeState();
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
 
     public ReturnHomeViewModel() {
         super("return home");
     }
 
-    public ReturnHomeState getState() {
-        return this.state;
-    }
-
-    public void setState(ReturnHomeState returnHomeState) {
-        this.state = returnHomeState;
-    }
-
     @Override
     public void firePropertyChanged() {
-        support.firePropertyChange("state", null, this.state);
+        support.firePropertyChange("state", null, null);
     }
 
     @Override

--- a/src/interface_adapter/start_new_game/StartNewGamePresenter.java
+++ b/src/interface_adapter/start_new_game/StartNewGamePresenter.java
@@ -1,6 +1,6 @@
 package interface_adapter.start_new_game;
 
-import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewModelManager;
 import interface_adapter.create_quiz.CreateQuizState;
 import interface_adapter.create_quiz.CreateQuizViewModel;
 import use_case.start_new_game.StartNewGameOutputBoundary;
@@ -9,11 +9,11 @@ import use_case.start_new_game.StartNewGameOutputData;
 public class StartNewGamePresenter implements StartNewGameOutputBoundary
 {
     private final CreateQuizViewModel createQuizViewModel;
-    private final ViewManagerModel viewManagerModel;
+    private final ViewModelManager viewModelManager;
 
-    public StartNewGamePresenter(ViewManagerModel viewManagerModel,
+    public StartNewGamePresenter(ViewModelManager viewModelManager,
                                  CreateQuizViewModel createQuizViewModel) {
-        this.viewManagerModel = viewManagerModel;
+        this.viewModelManager = viewModelManager;
         this.createQuizViewModel = createQuizViewModel;
     }
 
@@ -26,7 +26,7 @@ public class StartNewGamePresenter implements StartNewGameOutputBoundary
         createQuizStateState.setReadingType(outputData.defaultReadingType());
         createQuizViewModel.firePropertyChanged();
 
-        viewManagerModel.setActiveView(createQuizViewModel.getViewName());
-        viewManagerModel.firePropertyChanged();
+        viewModelManager.setActiveView(createQuizViewModel.getViewName());
+        viewModelManager.firePropertyChanged();
     }
 }

--- a/src/interface_adapter/start_new_game/StartNewGameViewModel.java
+++ b/src/interface_adapter/start_new_game/StartNewGameViewModel.java
@@ -11,7 +11,7 @@ public class StartNewGameViewModel extends ViewModel
     public static final String VIEW_SCORES_BUTTON_LABEL = "View Scores";
 
     public StartNewGameViewModel() {
-        super("new game");
+        super("Home Page");
     }
 
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);

--- a/src/interface_adapter/submit_quiz/SubmitQuizPresenter.java
+++ b/src/interface_adapter/submit_quiz/SubmitQuizPresenter.java
@@ -3,17 +3,22 @@ package interface_adapter.submit_quiz;
 import entity.quiz.SubmittedQuizDisplay;
 import entity.user.User;
 import interface_adapter.ViewModelManager;
+import interface_adapter.return_home.ReturnHomeState;
+import interface_adapter.return_home.ReturnHomeViewModel;
 import use_case.submit_quiz.SubmitQuizOutputBoundary;
 import use_case.submit_quiz.SubmitQuizOutputData;
 import view.ResultsView;
 
 public class SubmitQuizPresenter implements SubmitQuizOutputBoundary {
     private final SubmitQuizViewModel quizViewModel;
+    private final ReturnHomeViewModel returnHomeViewModel;
     private final ViewModelManager viewManager;
 
-    public SubmitQuizPresenter(ViewModelManager viewManager, SubmitQuizViewModel quizViewModel) {
+    public SubmitQuizPresenter(ViewModelManager viewManager, SubmitQuizViewModel quizViewModel,
+                               ReturnHomeViewModel returnHomeViewModel) {
         this.viewManager = viewManager;
         this.quizViewModel = quizViewModel;
+        this.returnHomeViewModel = returnHomeViewModel;
     }
 
     @Override
@@ -26,6 +31,10 @@ public class SubmitQuizPresenter implements SubmitQuizOutputBoundary {
 //
 //        user.addScore(quizDisplay.score());
 //        this.quizViewModel.setState(quizState);
+
+        ReturnHomeState returnHomeState = returnHomeViewModel.getState();
+        returnHomeState.setQuizDisplay(outputData.quizDisplay());
+        returnHomeViewModel.firePropertyChanged();
 
         viewManager.setActiveView(ResultsView.VIEW_NAME);
         viewManager.firePropertyChanged();

--- a/src/interface_adapter/submit_quiz/SubmitQuizPresenter.java
+++ b/src/interface_adapter/submit_quiz/SubmitQuizPresenter.java
@@ -2,15 +2,15 @@ package interface_adapter.submit_quiz;
 
 import entity.quiz.SubmittedQuizDisplay;
 import entity.user.User;
-import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewModelManager;
 import use_case.submit_quiz.SubmitQuizOutputBoundary;
 import use_case.submit_quiz.SubmitQuizOutputData;
 
 public class SubmitQuizPresenter implements SubmitQuizOutputBoundary {
     private final SubmitQuizViewModel quizViewModel;
-    private final ViewManagerModel viewManager;
+    private final ViewModelManager viewManager;
 
-    public SubmitQuizPresenter(ViewManagerModel viewManager, SubmitQuizViewModel quizViewModel) {
+    public SubmitQuizPresenter(ViewModelManager viewManager, SubmitQuizViewModel quizViewModel) {
         this.viewManager = viewManager;
         this.quizViewModel = quizViewModel;
     }

--- a/src/interface_adapter/view_scores/ViewScoresPresenter.java
+++ b/src/interface_adapter/view_scores/ViewScoresPresenter.java
@@ -1,6 +1,6 @@
 package interface_adapter.view_scores;
 
-import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewModelManager;
 import use_case.view_scores.ViewScoresOutputBoundary;
 import use_case.view_scores.ViewScoresOutputData;
 
@@ -10,11 +10,11 @@ import java.util.stream.Collectors;
 
 public class ViewScoresPresenter implements ViewScoresOutputBoundary {
     private final ViewScoresViewModel viewScoresViewModel;
-    private final ViewManagerModel viewManagerModel;
+    private final ViewModelManager viewModelManager;
 
-    public ViewScoresPresenter(ViewManagerModel viewManagerModel, ViewScoresViewModel viewScoresViewModel) {
+    public ViewScoresPresenter(ViewModelManager viewModelManager, ViewScoresViewModel viewScoresViewModel) {
         this.viewScoresViewModel = viewScoresViewModel;
-        this.viewManagerModel = viewManagerModel;
+        this.viewModelManager = viewModelManager;
     }
 
     @Override

--- a/src/interface_adapter/view_scores/ViewScoresViewModel.java
+++ b/src/interface_adapter/view_scores/ViewScoresViewModel.java
@@ -10,7 +10,7 @@ public class ViewScoresViewModel extends ViewModel {
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
 
     public ViewScoresViewModel() {
-        super("scores");
+        super("Home Page");
     }
 
     public ViewScoresState getState() {

--- a/src/use_case/return_home/ReturnHomeDataAccessInterface.java
+++ b/src/use_case/return_home/ReturnHomeDataAccessInterface.java
@@ -1,4 +1,0 @@
-package use_case.return_home;
-
-public interface ReturnHomeDataAccessInterface {
-}

--- a/src/use_case/return_home/ReturnHomeInputData.java
+++ b/src/use_case/return_home/ReturnHomeInputData.java
@@ -1,4 +1,0 @@
-package use_case.return_home;
-
-public record ReturnHomeInputData() {
-}

--- a/src/use_case/return_home/ReturnHomeInteractor.java
+++ b/src/use_case/return_home/ReturnHomeInteractor.java
@@ -1,4 +1,15 @@
 package use_case.return_home;
 
-public class ReturnHomeInteractor {
+public class ReturnHomeInteractor implements ReturnHomeInputBoundary {
+    private final ReturnHomeOutputBoundary presenter;
+
+    public ReturnHomeInteractor(ReturnHomeOutputBoundary presenter) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void execute()
+    {
+        presenter.prepareSuccessView();
+    }
 }

--- a/src/use_case/return_home/ReturnHomeOutputBoundary.java
+++ b/src/use_case/return_home/ReturnHomeOutputBoundary.java
@@ -1,5 +1,5 @@
 package use_case.return_home;
 
 public interface ReturnHomeOutputBoundary {
-    void prepareSuccessView(ReturnHomeOutputData outputData);
+    void prepareSuccessView();
 }

--- a/src/use_case/return_home/ReturnHomeOutputData.java
+++ b/src/use_case/return_home/ReturnHomeOutputData.java
@@ -1,4 +1,0 @@
-package use_case.return_home;
-
-public record ReturnHomeOutputData() {
-}

--- a/src/use_case/start_new_game/StartNewGameInteractor.java
+++ b/src/use_case/start_new_game/StartNewGameInteractor.java
@@ -1,10 +1,5 @@
 package use_case.start_new_game;
 
-import entity.DifficultyLevel;
-import entity.language.Language;
-import entity.reading.ReadingType;
-import use_case.create_quiz.CreateQuizDataAccessInterface;
-
 public class StartNewGameInteractor implements StartNewGameInputBoundary
 {
     private final StartNewGameDataAccessInterface dataAccessor;

--- a/src/view/ButtonsPanel.java
+++ b/src/view/ButtonsPanel.java
@@ -5,11 +5,12 @@ import java.awt.*;
 
 public class ButtonsPanel extends JPanel
 {
-    public ButtonsPanel()
+    public ButtonsPanel(int axis)
     {
-        this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-        this.setBorder(null);
-        this.setOpaque(false);
+        setLayout(new BoxLayout(this, axis));
+        setAlignmentX(Component.CENTER_ALIGNMENT);
+        setBorder(null);
+        setOpaque(false);
     }
 
     public JButton addGradientButton(String text, String fontName, Color backgroundColor,

--- a/src/view/CreateQuizView.java
+++ b/src/view/CreateQuizView.java
@@ -17,7 +17,7 @@ import java.beans.PropertyChangeListener;
 import java.util.Arrays;
 
 public class CreateQuizView extends BackgroundImagePanel implements ActionListener, PropertyChangeListener {
-    public static final String VIEW_NAME = "create quiz";
+    public static final String VIEW_NAME = "Create Quiz";
 
     private final CreateQuizController createQuizController;
     private final CreateQuizViewModel createQuizViewModel;
@@ -26,8 +26,6 @@ public class CreateQuizView extends BackgroundImagePanel implements ActionListen
     private final JComboBox<String> difficultyDropdown;
     private final JComboBox<String> readingTypeDropdown;
 
-    private final JButton takeQuiz;
-
     public CreateQuizView(CreateQuizController createQuizController, CreateQuizViewModel createQuizViewModel,
                           Image backgroundImage, Image headerImage) {
         super(backgroundImage);
@@ -35,7 +33,7 @@ public class CreateQuizView extends BackgroundImagePanel implements ActionListen
         this.createQuizViewModel = createQuizViewModel;
         createQuizViewModel.addPropertyChangeListener(this);
 
-        ButtonsPanel buttonPanel = new ButtonsPanel();
+        ButtonsPanel buttonPanel = new ButtonsPanel(BoxLayout.Y_AXIS);
         Color buttonBackgroundColor = new Color(144, 172, 245);
 
         JLabel title = new JLabel(new ImageIcon(headerImage));
@@ -56,7 +54,7 @@ public class CreateQuizView extends BackgroundImagePanel implements ActionListen
         LabeledDropdownPanel readingTypeInfo = new LabeledDropdownPanel(createJLabel(CreateQuizViewModel.READING_TYPE_DROPDOWN_LABEL),
                 readingTypeDropdown);
 
-        takeQuiz = buttonPanel.addGradientButton(CreateQuizViewModel.TAKE_QUIZ_BUTTON_LABEL,
+        JButton takeQuiz = buttonPanel.addGradientButton(CreateQuizViewModel.TAKE_QUIZ_BUTTON_LABEL,
                 ViewManager.BUTTON_FONT, buttonBackgroundColor, Color.BLACK, ViewManager.BUTTON_CURVATURE);
         buttonPanel.addSpacer();
         buttonPanel.addSpacer();

--- a/src/view/GameView.java
+++ b/src/view/GameView.java
@@ -23,9 +23,7 @@ public class GameView extends JSplitPane implements ActionListener, PropertyChan
 
     private final SubmitQuizViewModel submitQuizViewModel;
 
-    private JButton submitQuiz = null;
-
-    private final JPanel view1;
+    private final JPanel readingPanel;
     private final JPanel questionsPanel;
 
     public GameView(SubmitQuizViewModel submitQuizViewModel, SubmitQuizController submitQuizController) {
@@ -33,13 +31,17 @@ public class GameView extends JSplitPane implements ActionListener, PropertyChan
         this.submitQuizViewModel.addPropertyChangeListener(this);
 
         // Left half of panel
-        view1 = new JPanel();
+        JPanel view1 = new JPanel();
         view1.setLayout(new BoxLayout(view1, BoxLayout.Y_AXIS));
 
         JLabel header1 = new JLabel("Reading");
         header1.setAlignmentX(Component.CENTER_ALIGNMENT);
         header1.setFont(new Font(header1.getFont().getFontName(), Font.PLAIN, 25));
         view1.add(header1);
+
+        readingPanel = new JPanel();
+        readingPanel.setLayout(new BoxLayout(readingPanel, BoxLayout.Y_AXIS));
+        view1.add(readingPanel);
 
         // Right half of panel
         JPanel view2 = new JPanel();
@@ -64,17 +66,14 @@ public class GameView extends JSplitPane implements ActionListener, PropertyChan
         questionsPanelContainer.add(questionPanelWithSpace, BorderLayout.WEST);
         view2.add(questionsPanelContainer);
 
-        ButtonsPanel buttonsPanel = new ButtonsPanel();
+        ButtonsPanel buttonsPanel = new ButtonsPanel(BoxLayout.X_AXIS);
         Color buttonBackgroundColor2 = new Color(69, 196, 174);
 
         // Add submit quiz button to right view
-        submitQuiz = buttonsPanel.addGradientButton("Submit", ViewManager.BUTTON_FONT, buttonBackgroundColor2,
+        JButton submitQuiz = buttonsPanel.addGradientButton("Submit", ViewManager.BUTTON_FONT, buttonBackgroundColor2,
                 Color.BLACK, ViewManager.BUTTON_CURVATURE);
         submitQuiz.setMaximumSize(new Dimension(100, 30));
-
-        JPanel buttonsPanelContainer = new JPanel();
-        buttonsPanelContainer.add(buttonsPanel);
-        view2.add(buttonsPanelContainer);
+        view2.add(buttonsPanel);
 
         // Handle submit quiz button click
         submitQuiz.addActionListener(
@@ -106,12 +105,13 @@ public class GameView extends JSplitPane implements ActionListener, PropertyChan
 
         if (submitQuizState.getSubmitQuizError() != null)
         {
-            JOptionPane.showMessageDialog(null,
+            JOptionPane.showMessageDialog(this,
                     submitQuizState.getSubmitQuizError(), "Error", JOptionPane.ERROR_MESSAGE);
             submitQuizState.setSubmitQuizError(null);
         }
         else
         {
+            clearPreviousGame();
             ActiveQuizDisplay quizDisplay = submitQuizState.getQuiz().activeDisplay();
             updateLeftPanel(submitQuizState);
             updateRightPanel(quizDisplay);
@@ -132,9 +132,9 @@ public class GameView extends JSplitPane implements ActionListener, PropertyChan
         readingText.setWrapStyleWord(true);
         readingText.setEditable(false);
 
-        view1.add(title);
-        view1.add(author);
-        view1.add(readingText);
+        readingPanel.add(title);
+        readingPanel.add(author);
+        readingPanel.add(readingText);
     }
 
     private void updateRightPanel(ActiveQuizDisplay quizDisplay) {
@@ -143,11 +143,20 @@ public class GameView extends JSplitPane implements ActionListener, PropertyChan
 
         // Add each button group and question label to the view
         for (int i = 0; i < questions.length; i++) {
-            QuestionPanel questionPanel = new QuestionPanel(questions[i], choices[i], submitQuizViewModel, i);
+            QuestionPanel questionPanel = QuestionPanel.Builder.createActiveQuizPanel(questions[i], choices[i],
+                    submitQuizViewModel.getState().getAnswers(), i);
             questionsPanel.add(questionPanel);
             questionsPanel.add(Box.createVerticalGlue());
             questionPanel.add(createSpacer(PREF_SPACE_BETWEEN_QUESTION, MAX_SPACE_BETWEEN_QUESTION));
         }
+    }
+
+    private void clearPreviousGame()
+    {
+        questionsPanel.removeAll();
+        readingPanel.removeAll();
+        revalidate();
+        repaint();
     }
 
     private Box.Filler createSpacer(Dimension prefSize, Dimension maxSize)

--- a/src/view/HomePageView.java
+++ b/src/view/HomePageView.java
@@ -13,14 +13,11 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 public class HomePageView extends BackgroundImagePanel implements ActionListener, PropertyChangeListener {
-    public final static String VIEW_NAME = "home page";
+    public final static String VIEW_NAME = "Home Page";
 
     private final StartNewGameController startNewGameController;
     private final ViewScoresController viewScoresController;
     private final ViewScoresViewModel viewScoresViewModel;
-
-    private final JButton newGame;
-    private final JButton viewScores;
 
     public HomePageView(StartNewGameViewModel startNewGameViewModel, ViewScoresViewModel viewScoresViewModel,
                         StartNewGameController startNewGameController, ViewScoresController viewScoresController,
@@ -33,14 +30,14 @@ public class HomePageView extends BackgroundImagePanel implements ActionListener
         startNewGameViewModel.addPropertyChangeListener(this);
         viewScoresViewModel.addPropertyChangeListener(this);
 
-        ButtonsPanel buttonsPanel = new ButtonsPanel();
+        ButtonsPanel buttonsPanel = new ButtonsPanel(BoxLayout.Y_AXIS);
         Color buttonBackgroundColor1 = new Color(228, 215, 159);
         Color buttonBackgroundColor2 = new Color(215, 159, 228);
 
-        newGame = buttonsPanel.addGradientButton(StartNewGameViewModel.NEW_GAME_BUTTON_LABEL,
+        JButton newGame = buttonsPanel.addGradientButton(StartNewGameViewModel.NEW_GAME_BUTTON_LABEL,
                 ViewManager.BUTTON_FONT, buttonBackgroundColor1, Color.BLACK, ViewManager.BUTTON_CURVATURE);
         buttonsPanel.addSpacer();
-        viewScores = buttonsPanel.addGradientButton(StartNewGameViewModel.VIEW_SCORES_BUTTON_LABEL,
+        JButton viewScores = buttonsPanel.addGradientButton(StartNewGameViewModel.VIEW_SCORES_BUTTON_LABEL,
                 ViewManager.BUTTON_FONT, buttonBackgroundColor2, Color.BLACK, ViewManager.BUTTON_CURVATURE);
 
         newGame.addActionListener(

--- a/src/view/LoadingScreenView.java
+++ b/src/view/LoadingScreenView.java
@@ -10,7 +10,7 @@ import java.beans.PropertyChangeListener;
 import java.util.Queue;
 
 public class LoadingScreenView extends BackgroundImagePanel implements ActionListener, PropertyChangeListener {
-    public static final String VIEW_NAME = "loading screen";
+    public static final String VIEW_NAME = "Loading Screen";
 
     public LoadingScreenView(LoadingScreenViewModel loadingScreenViewModel,
                              Queue<Image> loadingAnimations) {

--- a/src/view/QuestionPanel.java
+++ b/src/view/QuestionPanel.java
@@ -1,21 +1,25 @@
 package view;
 
-import interface_adapter.submit_quiz.SubmitQuizViewModel;
-
 import javax.swing.*;
-import java.util.Arrays;
+import java.awt.*;
 
 public class QuestionPanel extends JPanel {
+    private static final Color RIGHT_ANSWER_TEXT_COLOR = new Color(12, 121, 5);
+    private static final Color WRONG_ANSWER_TEXT_COLOR = new Color(152, 9, 45);
 
-    public QuestionPanel(String question, String[] choices, SubmitQuizViewModel viewModel, Integer questionIndex)
+    private QuestionPanel()
     {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS)); // Set layout to vertical
+    }
+
+    private QuestionPanel(String question, String[] choices, Integer[] answers, Integer questionIndex)
+    {
+        this();
 
         JLabel questionLabel = new JLabel(question);
         this.add(questionLabel);
 
         ButtonGroup buttonGroup = new ButtonGroup();
-        Integer[] answers = viewModel.getState().getAnswers();
         for (int i = 0; i < choices.length; i++) {
             JRadioButton choice = new JRadioButton(choices[i]);
 
@@ -23,11 +27,73 @@ public class QuestionPanel extends JPanel {
             choice.addActionListener(evt -> {
                 if (evt.getSource().equals(choice)) {
                     answers[questionIndex] = finalI;
-                    System.out.println(Arrays.toString(answers));
                 }
             });
+
             buttonGroup.add(choice);
             this.add(choice);
+        }
+    }
+
+    private QuestionPanel(String question, String[] choices, Integer[] answers,
+                          Integer rightChoiceIndex, String explanation, Integer questionIndex)
+    {
+        this();
+
+        boolean answeredRight = rightChoiceIndex.equals(answers[questionIndex]);
+        JLabel scoreLabel = new JLabel((answeredRight ? "1" : "0") + "/1");
+        JLabel questionLabel = new JLabel(question);
+        questionLabel.setForeground(Color.GRAY);
+        this.add(scoreLabel);
+        this.add(questionLabel);
+
+        for (int i = 0; i < choices.length; i++) {
+            JRadioButton choice = new JRadioButton(choices[i]);
+            choice.setEnabled(false);
+            choice.setForeground(Color.GRAY);
+
+            if (i == answers[questionIndex])
+            {
+                choice.setSelected(true);
+            }
+
+            this.add(choice);
+        }
+
+        if(answeredRight)
+        {
+            scoreLabel.setForeground(RIGHT_ANSWER_TEXT_COLOR);
+        }
+        else
+        {
+            scoreLabel.setForeground(WRONG_ANSWER_TEXT_COLOR);
+
+            JLabel correctAnswerLabel = new JLabel("Correct Answer: " + choices[rightChoiceIndex]);
+            JLabel explanationLabel = new JLabel("Explanation: " + explanation);
+
+            correctAnswerLabel.setFont(new Font(correctAnswerLabel.getFont().getFontName(), Font.BOLD,
+                    correctAnswerLabel.getFont().getSize()));
+            explanationLabel.setFont(new Font(explanationLabel.getFont().getFontName(), Font.BOLD,
+                    explanationLabel.getFont().getSize()));
+
+            this.add(correctAnswerLabel);
+            this.add(explanationLabel);
+        }
+    }
+
+    public static class Builder
+    {
+        public static QuestionPanel createActiveQuizPanel(String question, String[] choices, Integer[] answers,
+                                                          Integer questionIndex)
+        {
+            return new QuestionPanel(question, choices, answers, questionIndex);
+        }
+
+        public static QuestionPanel createSubmittedQuizPanel(String question, String[] choices, Integer[] answers,
+                                                             Integer rightChoiceIndex, String explanation,
+                                                             Integer questionIndex)
+        {
+            return new QuestionPanel(question, choices, answers, rightChoiceIndex, explanation, questionIndex);
         }
     }
 }

--- a/src/view/ResultsView.java
+++ b/src/view/ResultsView.java
@@ -1,5 +1,8 @@
 package view;
 
+import interface_adapter.return_home.ReturnHomeController;
+import interface_adapter.return_home.ReturnHomeViewModel;
+
 import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -7,10 +10,16 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 public class ResultsView extends JPanel implements ActionListener, PropertyChangeListener {
-    private final String viewName = "Results View";
-    @Override
-    public void actionPerformed(ActionEvent e) {
+    private final static String VIEW_NAME = "Results View";
 
+    public ResultsView(ReturnHomeViewModel returnHomeViewModel, ReturnHomeController returnHomeController)
+    {
+        returnHomeViewModel.addPropertyChangeListener(this);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent evt) {
+        JOptionPane.showConfirmDialog(this, "action not implemented yet.");
     }
 
     @Override

--- a/src/view/ResultsView.java
+++ b/src/view/ResultsView.java
@@ -1,20 +1,67 @@
 package view;
 
+import entity.quiz.SubmittedQuizDisplay;
 import interface_adapter.return_home.ReturnHomeController;
+import interface_adapter.return_home.ReturnHomeState;
 import interface_adapter.return_home.ReturnHomeViewModel;
 
 import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
-public class ResultsView extends JPanel implements ActionListener, PropertyChangeListener {
-    public static final String VIEW_NAME = "Results View";
+public class ResultsView extends JScrollPane implements ActionListener, PropertyChangeListener {
+    public static final String VIEW_NAME = "Results";
+
+    private static final Dimension PREF_SPACE_BETWEEN_QUESTION = new Dimension(0, 15);
+    private static final Dimension MAX_SPACE_BETWEEN_QUESTION = new Dimension(0, 20);
+
+    private final JPanel questionsPanel;
 
     public ResultsView(ReturnHomeViewModel returnHomeViewModel, ReturnHomeController returnHomeController)
     {
+        JPanel content = new JPanel();
         returnHomeViewModel.addPropertyChangeListener(this);
+        content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS));
+
+        JLabel header = new JLabel(ReturnHomeViewModel.HEADER_LABEL);
+        header.setAlignmentX(Component.CENTER_ALIGNMENT);
+        header.setFont(new Font(header.getFont().getFontName(), Font.PLAIN, 25));
+        content.add(header);
+
+        questionsPanel = new JPanel();
+        questionsPanel.setLayout(new BoxLayout(questionsPanel, BoxLayout.Y_AXIS));
+
+        JPanel questionPanelWithSpace = new JPanel();
+        questionPanelWithSpace.setLayout(new BoxLayout(questionPanelWithSpace, BoxLayout.X_AXIS));
+        questionPanelWithSpace.add(createSpacer(new Dimension(15, 0), new Dimension(40, 0)));
+        questionPanelWithSpace.add(questionsPanel);
+
+        JPanel questionsPanelContainer = new JPanel();
+        questionsPanelContainer.setLayout(new BorderLayout());
+        questionsPanelContainer.add(questionPanelWithSpace, BorderLayout.WEST);
+        content.add(questionsPanelContainer);
+
+        ButtonsPanel buttonsPanel = new ButtonsPanel(BoxLayout.X_AXIS);
+        Color buttonBackgroundColor2 = new Color(17, 61, 145);
+
+        JButton returnHome = buttonsPanel.addGradientButton(ReturnHomeViewModel.RETURN_HOME_BUTTON_LABEL,
+                ViewManager.BUTTON_FONT, buttonBackgroundColor2, Color.BLACK, ViewManager.BUTTON_CURVATURE);
+        returnHome.setMaximumSize(new Dimension(175, 30));
+        content.add(buttonsPanel);
+
+        // Handle return home button click
+        returnHome.addActionListener(
+                evt -> {
+                    if (evt.getSource().equals(returnHome)) {
+                        returnHomeController.execute();
+                    }
+                }
+        );
+
+        setViewportView(content);
     }
 
     @Override
@@ -24,6 +71,31 @@ public class ResultsView extends JPanel implements ActionListener, PropertyChang
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
+        ReturnHomeState returnHomeState = (ReturnHomeState) evt.getNewValue();
+        SubmittedQuizDisplay quizDisplay = returnHomeState.getQuizDisplay();
 
+        clearPreviousGame();
+
+        // Add each button group and question label to the view
+        for (int i = 0; i < quizDisplay.questions().length; i++) {
+            QuestionPanel questionPanel = QuestionPanel.Builder.createSubmittedQuizPanel(quizDisplay.questions()[i],
+                    quizDisplay.choices()[i], quizDisplay.chosenChoices(), quizDisplay.answers()[i],
+                    quizDisplay.explanations()[i], i);
+            questionsPanel.add(questionPanel);
+            questionsPanel.add(Box.createVerticalGlue());
+            questionPanel.add(createSpacer(PREF_SPACE_BETWEEN_QUESTION, MAX_SPACE_BETWEEN_QUESTION));
+        }
+    }
+
+    private Box.Filler createSpacer(Dimension prefSize, Dimension maxSize)
+    {
+        return new Box.Filler(prefSize, prefSize, maxSize);
+    }
+
+    private void clearPreviousGame()
+    {
+        questionsPanel.removeAll();
+        revalidate();
+        repaint();
     }
 }

--- a/src/view/ResultsView.java
+++ b/src/view/ResultsView.java
@@ -76,6 +76,10 @@ public class ResultsView extends JScrollPane implements ActionListener, Property
 
         clearPreviousGame();
 
+        JLabel overallScore = new JLabel("Overall Score: " + Math.round(quizDisplay.score()) + "%");
+        overallScore.setFont(new Font(overallScore.getFont().getName(), Font.BOLD, 17));
+        questionsPanel.add(overallScore);
+
         // Add each button group and question label to the view
         for (int i = 0; i < quizDisplay.questions().length; i++) {
             QuestionPanel questionPanel = QuestionPanel.Builder.createSubmittedQuizPanel(quizDisplay.questions()[i],

--- a/src/view/ViewManager.java
+++ b/src/view/ViewManager.java
@@ -1,6 +1,6 @@
 package view;
 
-import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewModelManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -14,10 +14,10 @@ public class ViewManager implements PropertyChangeListener {
     private final CardLayout cardLayout;
     private final JPanel views;
 
-    public ViewManager(JPanel views, CardLayout cardLayout, ViewManagerModel viewManagerModel) {
+    public ViewManager(JPanel views, CardLayout cardLayout, ViewModelManager viewModelManager) {
         this.views = views;
         this.cardLayout = cardLayout;
-        viewManagerModel.addPropertyChangeListener(this);
+        viewModelManager.addPropertyChangeListener(this);
     }
 
     @Override


### PR DESCRIPTION
## Pull Request Summary

Implemented the return home use case

### Description

In this pull request, I have implemented a results page feature at the end of the quiz. Now, users can easily review their performance in the quiz by seeing which questions they answered correctly and incorrectly. Additionally, a convenient "Return Home" button has been added at the bottom of the results page, allowing users to navigate back to the home screen and start a new quiz all over again. To achieve this, I extended the functionality of both the game view and the results view. Specifically, I introduced new methods to clear the previous view, allowing the program to display a new quiz when prompted.

### Features Added

- Implemented a brief "Return Home" use case, that simply changes the view to the "Home Page" view.
- Developed a dedicated results view where users can access their overall scores and review both correct and incorrect answers. Each incorrect answer is accompanied by an informative explanation, helping the user's learning experience.
- Incorporated a "Return Home" button within the results view, allowing for easy navigation back to the home page. This enables users to initiate new quizzes over and over again.
- Added methods to clear views after quiz submission, which lets the JPanels to be refilled with the new quiz's information

### Screenshot of the results view
![ResultsView](https://github.com/manimeh/BiblioLinguist/assets/144498679/c9264eaf-a5bf-42b5-adde-130a77f8d1e0)

### Additional Notes
Feedback on the implementation of the use case is highly welcomed. If you have any specific concerns or questions, please feel free to let me know.